### PR TITLE
Allow VCS install using GLUONTS_FALLBACK_VERSION

### DIFF
--- a/src/gluonts/meta/_version.py
+++ b/src/gluonts/meta/_version.py
@@ -60,6 +60,7 @@ In `setup.py`, you need to import and use this file like this:
     )
 """
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -250,4 +251,4 @@ def cmdclass():
     return {"sdist": sdist, "build_py": build_py}
 
 
-__version__ = get_version(fallback="0.0.0")
+__version__ = get_version(fallback=os.environ.get("GLUONTS_FALLBACK_VERSION", "0.0.0"))


### PR DESCRIPTION
going into https://github.com/awslabs/gluonts/pull/3007

allow install without having the git tags locally:
```
export GLUONTS_FALLBACK_VERSION=0.13.8
pip install 'gluonts @ https://github.com/ddelange/gluonts/archive/refs/heads/patch-1.zip'
```

